### PR TITLE
Guard socket language emission

### DIFF
--- a/frontend/src/app/services/language.service.ts
+++ b/frontend/src/app/services/language.service.ts
@@ -37,7 +37,10 @@ export class LanguageService {
     this.currentLanguage.set(language);
     localStorage.setItem('language', language)
     this.translate.use(language);
-    this.socketService.setUserLanguage(language);
+    // Guard against emitting before socket connection to avoid runtime errors
+    if (this.socketService['socket']) {
+      this.socketService.setUserLanguage(language);
+    }
   }
 
   getLanguages() {


### PR DESCRIPTION
## Summary
- prevent socket language emission when no connection exists
- clarify guard comment to avoid runtime errors

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68af297ab55083339c9e339863aa5b2b